### PR TITLE
Fix ModuleNotFoundError when installed with pipx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     package_dir={'': 'src'},
     entry_points={
         'console_scripts': [
-            'ClipDropSDXL = ClipDropSDXL.main:main'
+            'ClipDropSDXL = ClipDropSDXL:main'
         ]
     },
     install_requires=[


### PR DESCRIPTION
>    from ClipDropSDXL.main import main                                         
> ModuleNotFoundError: No module named 'ClipDropSDXL.main'; 'ClipDropSDXL' is not a package